### PR TITLE
refactor: centralize env variable handling

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,13 @@
+const getEnvVar = (key: string): string => {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing environment variable: ${key}`);
+  }
+  return value;
+};
+
+export const env = {
+  NEXT_PUBLIC_SUPABASE_URL: getEnvVar("NEXT_PUBLIC_SUPABASE_URL"),
+  NEXT_PUBLIC_SUPABASE_ANON_KEY: getEnvVar("NEXT_PUBLIC_SUPABASE_ANON_KEY"),
+};
+

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -1,13 +1,14 @@
 // lib/supabase-server.ts
 import { createServerClient } from "@supabase/ssr";
 import { cookies } from "next/headers";
+import { env } from "./env";
 
 export async function createServerClientWithCookies() {
   const cookieStore = await cookies();
 
   return createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
     {
       cookies: {
         getAll() {

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,8 +1,9 @@
 import { createBrowserClient } from "@supabase/ssr";
+import { env } from "./env";
 
 export function createClient() {
   return createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    env.NEXT_PUBLIC_SUPABASE_URL,
+    env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   );
 }


### PR DESCRIPTION
## Summary
- validate required Supabase environment variables in a dedicated helper
- use validated env values in Supabase browser and server clients

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b895354f9c8333898b957f8b0e1296