### PR TITLE
feat: add generated database types

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,0 +1,66 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[];
+
+export interface Database {
+  public: {
+    Tables: {
+      jobs: {
+        Row: {
+          id: string;
+          user_id: string;
+          title: string;
+          company: string | null;
+          url: string;
+          source: string;
+          created_at: string;
+          posted_at: string | null;
+        };
+        Insert: {
+          id?: string;
+          user_id: string;
+          title: string;
+          company?: string | null;
+          url: string;
+          source: string;
+          created_at?: string;
+          posted_at?: string | null;
+        };
+        Update: {
+          id?: string;
+          user_id?: string;
+          title?: string;
+          company?: string | null;
+          url?: string;
+          source?: string;
+          created_at?: string;
+          posted_at?: string | null;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "jobs_user_id_fkey";
+            columns: ["user_id"];
+            referencedRelation: "users";
+            referencedColumns: ["id"];
+          }
+        ];
+      };
+    };
+    Views: {
+      [_ in never]: never;
+    };
+    Functions: {
+      [_ in never]: never;
+    };
+    Enums: {
+      [_ in never]: never;
+    };
+    CompositeTypes: {
+      [_ in never]: never;
+    };
+  };
+}

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -1,11 +1,4 @@
 // src/types/job.ts
-export interface Job {
-  id: string;
-  user_id: string;
-  title: string;
-  company: string | null;
-  url: string;
-  source: string;
-  created_at: string;       // ISO timestamp from Supabase
-  posted_at: string | null; // ISO or null (if source doesn't provide)
-}
+import type { Database } from "./database";
+
+export type Job = Database["public"]["Tables"]["jobs"]["Row"];


### PR DESCRIPTION
## Summary
- add Supabase-generated database types
- derive Job from schema and use typed query on dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8954759ec8333aaae8bff624f776e